### PR TITLE
Update to PHPUnit 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 vendor/
 phpunit.xml
+.phpunit.result.cache
 composer.lock
 scratchpad.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 7
-  - 7.1
-  - 7.2
   - 7.3
   - 7.4
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": ">=7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0.8"
+        "phpunit/phpunit": "^9.4.0"
     },
     "autoload": {
         "files": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,13 @@
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="Tests">
-            <directory suffix="test.php">test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Tests">
+      <directory suffix="test.php">test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This drops support for PHP 7.2 and under, and enables support for the upcoming PHP 8.